### PR TITLE
Arm refactor

### DIFF
--- a/src/main/java/frc/team5115/Classes/Hardware/HardwareArm.java
+++ b/src/main/java/frc/team5115/Classes/Hardware/HardwareArm.java
@@ -106,26 +106,6 @@ public class HardwareArm extends SubsystemBase{
         setBottomWinch(0);
         setTurn(0);
     }
-    
-    public double getTurnCurrent(){
-        return intakeTurn.getOutputCurrent();
-    }
-
-    public double getTopCurrent(){
-        return intakeTop.getOutputCurrent();
-    }
-    
-    public double getBottomCurrent(){
-        return intakeBottom.getOutputCurrent();
-    }
-
-    public double getTopEncoder(){
-        return (TopWinchEncoder.getPosition());
-    }
-
-    public double getBottomEncoder(){
-        return (BottomWinchEncoder.getPosition());
-    }
 
     public double getTopVelocity(){
         return -(TopWinchEncoder.getVelocity());
@@ -155,7 +135,7 @@ public class HardwareArm extends SubsystemBase{
     public double getTopWinchLength() {
         //System.out.println((getTopEncoder()/7)*(WinchDiameter*3.14159));
         //System.out.println((getBottomEncoder()/7)*(WinchDiameter));
-        return (getTopEncoder()/7)*(WinchDiameter);
+        return (TopWinchEncoder.getPosition()/7)*(WinchDiameter);
     
     }
 
@@ -165,7 +145,7 @@ public class HardwareArm extends SubsystemBase{
     public double getBottomWinchLength() {
         //System.out.println((getBottomEncoder()/7)*(WinchDiameter*3.14159));
         //System.out.println((getBottomEncoder()/7)*(WinchDiameter));
-        return (getBottomEncoder()/7)*(WinchDiameter);
+        return (BottomWinchEncoder.getPosition()/7)*(WinchDiameter);
     }
 
     /** 
@@ -182,7 +162,6 @@ public class HardwareArm extends SubsystemBase{
     private double angleFromSensors() {
         final double navxPitch = navx.getPitchDeg();
         final double bnoPitch = i2cHandler.getPitch();
-        // return Math.round(NAVx.clampAngle(bnoPitch - navxPitch)*100.0)/100.0;
         return NAVx.clampAngle(bnoPitch - navxPitch);
     }
 

--- a/src/main/java/frc/team5115/Classes/Software/Arm.java
+++ b/src/main/java/frc/team5115/Classes/Software/Arm.java
@@ -2,10 +2,8 @@ package frc.team5115.Classes.Software;
 
 import com.revrobotics.CANSparkMax;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import frc.team5115.Classes.Acessory.I2CHandler;
 import frc.team5115.Classes.Hardware.HardwareArm;
 import frc.team5115.Classes.Hardware.HardwareIntake;
-import frc.team5115.Classes.Hardware.NAVx;
 import edu.wpi.first.math.controller.PIDController;
 
 /**

--- a/src/main/java/frc/team5115/Classes/Software/Arm.java
+++ b/src/main/java/frc/team5115/Classes/Software/Arm.java
@@ -2,8 +2,10 @@ package frc.team5115.Classes.Software;
 
 import com.revrobotics.CANSparkMax;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.team5115.Classes.Acessory.I2CHandler;
 import frc.team5115.Classes.Hardware.HardwareArm;
 import frc.team5115.Classes.Hardware.HardwareIntake;
+import frc.team5115.Classes.Hardware.NAVx;
 import edu.wpi.first.math.controller.PIDController;
 
 /**
@@ -15,12 +17,11 @@ public class Arm extends SubsystemBase{
     private static final double TURN_PID_KI = 0.0;
     private static final double TURN_PID_KD = 0.0004;
     
-    private HardwareArm intake;
+    private HardwareArm hardwareArm;
     public HardwareIntake h;
     private double topLength = 0;
     private double bottomLength = 0;
     private double angle = -90;
-    private double speed = 0.25;
 
     private double topKp = 0.113;
     private double bottomKp = 0.115;
@@ -38,11 +39,11 @@ public class Arm extends SubsystemBase{
 	 * @param hardwareArm - The arm hardware subsystem to be used
 	 * @param hardwareIntake - The intake hardware subsystem to be used
 	 */
-    public Arm(HardwareArm hardwareArm, HardwareIntake hardwareIntake){
-        intake = hardwareArm;
+    public Arm(HardwareIntake hardwareIntake, HardwareArm hardwareArm){
+        this.hardwareArm = hardwareArm;
         h =hardwareIntake;
         zeroArm();
-        intake.setEncoders(topLength, -90);
+        hardwareArm.setEncoders(topLength, -90);
         turnController.setTolerance(TURN_PID_TOLERANCE);
     }
 
@@ -75,10 +76,6 @@ public class Arm extends SubsystemBase{
         setBottomPID(0.115);
     }
 
-    public void setTopWinchSpeed(){
-        intake.setTopWinch(speed);
-    }
-
 	/**
 	 * Extends or retracts the arm to the specified length.
 	 * @param length - The target arm length
@@ -88,32 +85,8 @@ public class Arm extends SubsystemBase{
         bottomLength = length;
     }
 
-    public void setNegTopWinchSpeed(){
-        intake.setTopWinch(-speed);
-    }
-
-    public void setBottomWinchSpeed(){
-        intake.setBottomWinch(speed);
-    }
-
-    public void setNegBottomWinchSpeed(){
-        intake.setBottomWinch(-speed);
-    }
-
-    public void setTurnSpeed(){
-        intake.setTurn(speed);
-    }
-
-    public void topWinchController(){
-        topWinchController.calculate(intake.getTopWinchLength(), topLength);
-    }
-
     public void topWinchSetLength(double length){
         this.topLength = length;
-    }
-
-    public void bottomWinchController(){
-        bottomWinchController.calculate(intake.getBottomWinchLength(), bottomLength);
     }
 
     public void bottomWinchSetLength(double length){
@@ -122,17 +95,6 @@ public class Arm extends SubsystemBase{
 
     public void turnSetAngle(double angle){
         this.angle = angle;
-    }
-
-    public void setArmUp(){
-        //angle = 25.5;
-        angle = 20;// for ff
-        System.out.println("up");
-    }
-
-    public void setArmDown(){
-        angle = -20;
-        System.out.println("down");
     }
 
     public void turnUp() {
@@ -163,75 +125,82 @@ public class Arm extends SubsystemBase{
 	 * Disable brake mode on the arm's motors.
 	 */
     public void disableBrake(){
-        intake.disableBrake();
+        hardwareArm.disableBrake();
     }
 
 	/**
 	 * Enable brake mode on the arm's motors.
 	 */
     public void enableBrake(){
-        intake.enableBrake();
+        hardwareArm.enableBrake();
     }
 
     public void updateController(){
         if(bottomLength>5 || topLength>5){
-            intake.FF = false;
+            hardwareArm.FF = false;
         }
         else{
-            intake.FF = true;
+            hardwareArm.FF = true;
         }
 
         // final double delta = angle - intake.getArmDeg();
-        final double pidOutput = turnController.calculate(intake.getArmDeg(), angle);
+        final double pidOutput = turnController.calculate(hardwareArm.getArmDeg(), angle);
         
         if (!turnController.atSetpoint()) {
-            intake.setTurn(pidOutput);
+            hardwareArm.setTurn(pidOutput);
         }
 
         if(armcontrol){
             
-            double topSpeed = topWinchController.calculate(intake.getTopWinchLength(), topLength);
-            double bottomSpeed = bottomWinchController.calculate(intake.getBottomWinchLength(), bottomLength);
-            intake.setTopWinch(topSpeed);
-            intake.setBottomWinch(bottomSpeed);
+            double topSpeed = topWinchController.calculate(hardwareArm.getTopWinchLength(), topLength);
+            double bottomSpeed = bottomWinchController.calculate(hardwareArm.getBottomWinchLength(), bottomLength);
+            hardwareArm.setTopWinch(topSpeed);
+            hardwareArm.setBottomWinch(bottomSpeed);
         }
     }
 
 
     public double getTopWinchLength(){
-        return intake.getTopWinchLength();
+        return hardwareArm.getTopWinchLength();
     }
 
     public double getBottomWinchLength(){
-        return intake.getBottomWinchLength();
+        return hardwareArm.getBottomWinchLength();
+    }
+
+    public double getBottomWinchVelocity() {
+        return hardwareArm.getBottomVelocity();
+    }
+
+    public double getTopWinchVelocity() {
+        return hardwareArm.getTopVelocity();
     }
 
     public void zeroArm(){
-        intake.setEncoders(0, -100.0);
+        hardwareArm.setEncoders(0, -100.0);
     }
 
     public void zeroLength(double angle){
-        intake.setEncoders(0, angle);
+        hardwareArm.setEncoders(0, angle);
     }
 
-
     public boolean getFault(CANSparkMax.FaultID f){
-        return intake.getFault(f);
+        return hardwareArm.getFault(f);
     }
 
     public void stop(){
-        intake.stop();
-    }
-
-    public void moveTop(){
-        intake.setTopWinch(-0.2);
-    }
-
-    public void moveBottom(){
-        intake.setBottomWinch(-0.2);
+        hardwareArm.stop();
     }
 
     public double getAngle() {
-        return intake.getArmDeg();
+        return hardwareArm.getArmDeg();
+    }
+
+    public void setTopWinchSpeed(double speed) {
+        hardwareArm.setTopWinch(speed);
+    }
+
+    public void setBottomWinchSpeed(double speed) {
+        hardwareArm.setBottomWinch(speed);
     }
 }

--- a/src/main/java/frc/team5115/Classes/Software/Drivetrain.java
+++ b/src/main/java/frc/team5115/Classes/Software/Drivetrain.java
@@ -1,6 +1,6 @@
 package frc.team5115.Classes.Software;
 
-import static frc.team5115.Constants.*;
+import frc.team5115.Constants;
 
 import java.util.Optional;
 import org.photonvision.EstimatedRobotPose;
@@ -51,14 +51,14 @@ public class Drivetrain extends SubsystemBase{
     public static final double bA = 10;
     public static final double MaxArea = 0.1;
 
-    public Drivetrain(PhotonVision photonVision, Arm arm, NAVx nav) {
+    public Drivetrain(PhotonVision photonVision, HardwareDrivetrain hardwareDrivetrain, NAVx nav) {
         this.photonVision = photonVision;
         throttle = new ThrottleControl(3, -3, 0.2);
         anglePID = new PIDController(0.019, 0.0001, 0.0012);
         
-        drivetrain = new HardwareDrivetrain(arm);
+        drivetrain = hardwareDrivetrain;
         ramseteController = new RamseteController();
-        kinematics = new DifferentialDriveKinematics(TRACKING_WIDTH_METERS);
+        kinematics = new DifferentialDriveKinematics(Constants.TRACKING_WIDTH_METERS);
         navx = nav;
     }
 
@@ -88,14 +88,14 @@ public class Drivetrain extends SubsystemBase{
 	 * @return The distance the left side of the drivetrain has traveled
 	 */
     public double getLeftDistance(){
-        return drivetrain.getEncoderDistance(BACK_LEFT_MOTOR_ID);
+        return drivetrain.getEncoderDistance(Constants.BACK_LEFT_MOTOR_ID);
     }
 
 	/**
 	 * @return The distance the right side of the drivetrain has traveled
 	 */
     public double getRightDistance(){
-        return drivetrain.getEncoderDistance(BACK_RIGHT_MOTOR_ID);
+        return drivetrain.getEncoderDistance(Constants.BACK_RIGHT_MOTOR_ID);
     }
 
 	/**
@@ -392,7 +392,7 @@ public class Drivetrain extends SubsystemBase{
             rightSpd = -(d - HUB_DISTANCE)*hD;
             */
             double yangle = 0; 
-            leftSpeed = -(TARGET_ANGLE - yangle)*hD;
+            leftSpeed = -(Constants.TARGET_ANGLE - yangle)*hD;
             leftSpeed = Math.max(-0.3, Math.min(0.3, leftSpeed));
             rightSpeed = leftSpeed;
             drivetrain.plugAndFFDrive(leftSpeed, rightSpeed);

--- a/src/main/java/frc/team5115/Commands/Auto/AutoCommandGroup.java
+++ b/src/main/java/frc/team5115/Commands/Auto/AutoCommandGroup.java
@@ -16,16 +16,14 @@ import frc.team5115.Commands.Intake.RawIntakeCommands.IntakeTurn;
 import frc.team5115.Classes.Software.Paths;
 
 public class AutoCommandGroup extends SequentialCommandGroup {
-    Drivetrain drivetrain;
-    Arm arm;
-    HardwareArm hArm;
-    HardwareIntake hIntake;
-	Paths paths;
+    final Drivetrain drivetrain;
+    final Arm arm;
+    final HardwareIntake hIntake;
+	final Paths paths;
 
-    public AutoCommandGroup(Drivetrain drivetrain, Arm arm, HardwareArm hArm, HardwareIntake hIntake, boolean inIdealPosition){
+    public AutoCommandGroup(Drivetrain drivetrain, Arm arm, HardwareIntake hIntake, boolean inIdealPosition){
         this.arm = arm;
         this.drivetrain = drivetrain;
-        this.hArm = hArm;
         this.hIntake = hIntake;
 		this.paths = new Paths();
 /* 
@@ -68,12 +66,12 @@ public class AutoCommandGroup extends SequentialCommandGroup {
 	 */
     private void PathPlannerHighNodeOld() {
 		addCommands(
-            new StartupWinch(arm, hArm, hIntake),
+            new StartupWinch(arm, hIntake),
             new InstantCommand(hIntake :: TurnIn),
             new HighNode(arm),
             new IntakeTurn(arm, 10),
 			new InstantCommand(hIntake :: StopMotor),
-            new Stow(arm, hArm, hIntake),
+            new Stow(arm, hIntake),
 			drivetrain.getRamseteCommand(paths.SideAutoPt1),
 			new GroundPickup(arm),
 			new InstantCommand(hIntake :: TurnIn),
@@ -91,14 +89,14 @@ public class AutoCommandGroup extends SequentialCommandGroup {
 	 */
 	private void PathPlannerHighNode() {
 		HashMap<String, Command> eventMap = new HashMap<>();
-		eventMap.put("Stow", new Stow(arm, hArm, hIntake));
+		eventMap.put("Stow", new Stow(arm, hIntake));
 		eventMap.put("Intake", new InstantCommand(hIntake :: TurnIn));
 		eventMap.put("High Node", new HighNode(arm));
 		eventMap.put("Arm Down 10", new IntakeTurn(arm, 10));
 		eventMap.put("Stop Intake", new InstantCommand(hIntake :: StopMotor));
 		eventMap.put("Stow With Cone", new StowCone(arm));
 		eventMap.put("Ground Pickup", new GroundPickup(arm));
-		eventMap.put("Down & Stow", new IntakeTurn(arm, 10).andThen(new Stow(arm, hArm, hIntake)));
+		eventMap.put("Down & Stow", new IntakeTurn(arm, 10).andThen(new Stow(arm, hIntake)));
 
 		addCommands(new FollowPathWithEvents(drivetrain.getRamseteCommand(paths.SideAuto), paths.SideAuto.getMarkers(), eventMap));
 	}
@@ -137,11 +135,11 @@ public class AutoCommandGroup extends SequentialCommandGroup {
 	 */
     private void BasicHighNode() {
         addCommands(
-            new StartupWinch(arm, hArm, hIntake),     
+            new StartupWinch(arm, hIntake),     
             new InstantCommand(hIntake :: TurnIn),
             new HighNode(arm),
             new IntakeTurn(arm, 10),
-            new Stow(arm, hArm, hIntake),
+            new Stow(arm, hIntake),
             new DriveForward(drivetrain, -3.5, 1.3) // back up to node
             //new Stow(arm, hArm, hIntake),
             //new DriveTurn(drivetrain, 170),
@@ -160,7 +158,7 @@ public class AutoCommandGroup extends SequentialCommandGroup {
     private void scoreHighWDock() {
         // should start facing towards grid
         addCommands(
-            new StartupWinch(arm, hArm, hIntake),     
+            new StartupWinch(arm, hIntake),     
             new InstantCommand(hIntake :: TurnIn),
             new HighNode(arm),
             new IntakeTurn(arm, 10),
@@ -176,23 +174,23 @@ public class AutoCommandGroup extends SequentialCommandGroup {
 	 */
 	private void scoreHighWDockPathPlanner() {
 		addCommands(
-			new StartupWinch(arm, hArm, hIntake),
+			new StartupWinch(arm, hIntake),
 			new InstantCommand(hIntake :: TurnIn),
 			new HighNode(arm),
 			new IntakeTurn(arm, 10),
 			new InstantCommand(hIntake :: StopMotor),
-			new Stow(arm, hArm, hIntake),
+			new Stow(arm, hIntake),
 			drivetrain.getRamseteCommand(paths.ScoreHighWithDock)
 		);
 	}
 
     private void superIdeal() {
         addCommands(
-            new StartupWinch(arm, hArm, hIntake),     
+            new StartupWinch(arm, hIntake),     
             new InstantCommand(hIntake :: TurnIn),
             new HighNode(arm),
             new IntakeTurn(arm, 10),
-            new Stow(arm, hArm, hIntake),
+            new Stow(arm, hIntake),
             new DriveForward(drivetrain, -0.26, 0.5), // back up to node
             //new Stow(arm, hArm, hIntake),
             new DriveTurn(drivetrain, 180),

--- a/src/main/java/frc/team5115/Commands/Intake/CombinedIntakeCommands/GroundPickup.java
+++ b/src/main/java/frc/team5115/Commands/Intake/CombinedIntakeCommands/GroundPickup.java
@@ -6,14 +6,11 @@ import frc.team5115.Commands.Intake.RawIntakeCommands.IntakeExtend;
 import frc.team5115.Commands.Intake.RawIntakeCommands.IntakeTurn;
 
 public class GroundPickup extends SequentialCommandGroup {
-    Arm intake;
-
-    public GroundPickup(Arm intake){
-        this.intake = intake;
+    public GroundPickup(Arm arm){
         addCommands(
-            new IntakeExtend(intake, 0),
-            new IntakeTurn(intake, -45),
-            new IntakeExtend(intake, 17.5)
+            new IntakeExtend(arm, 0),
+            new IntakeTurn(arm, -45),
+            new IntakeExtend(arm, 17.5)
         );
     }
 }

--- a/src/main/java/frc/team5115/Commands/Intake/CombinedIntakeCommands/HighNode.java
+++ b/src/main/java/frc/team5115/Commands/Intake/CombinedIntakeCommands/HighNode.java
@@ -7,16 +7,16 @@ import frc.team5115.Commands.Intake.RawIntakeCommands.IntakeExtend;
 import frc.team5115.Commands.Intake.RawIntakeCommands.IntakeTurn;
 
 public class HighNode extends CommandBase {
-    Arm intake;
+    Arm arm;
     WrappedHighNode wrappedHighNode; 
 
-    public HighNode(Arm intake){
-        this.intake = intake;
+    public HighNode(Arm arm){
+        this.arm = arm;
     }
 
     @Override
     public void initialize() {
-        wrappedHighNode = new WrappedHighNode(intake);
+        wrappedHighNode = new WrappedHighNode(arm);
         wrappedHighNode.schedule();
     }
 
@@ -38,9 +38,9 @@ public class HighNode extends CommandBase {
             }
 
             addCommands(
-                new IntakeExtend(intake, 0),
-                new IntakeTurn(intake, angle),
-                new IntakeExtend(intake, length)
+                new IntakeExtend(arm, 0),
+                new IntakeTurn(arm, angle),
+                new IntakeExtend(arm, length)
             );
         }
     }

--- a/src/main/java/frc/team5115/Commands/Intake/CombinedIntakeCommands/MiddleNode.java
+++ b/src/main/java/frc/team5115/Commands/Intake/CombinedIntakeCommands/MiddleNode.java
@@ -7,16 +7,16 @@ import frc.team5115.Commands.Intake.RawIntakeCommands.IntakeExtend;
 import frc.team5115.Commands.Intake.RawIntakeCommands.IntakeTurn;
 
 public class MiddleNode extends CommandBase {
-    Arm intake;
+    Arm arm;
     WrappedMiddleNode wrappedMiddleNode;
 
-    public MiddleNode(Arm intake){
-        this.intake = intake;
+    public MiddleNode(Arm arm){
+        this.arm = arm;
     }
 
     @Override
     public void initialize() {
-        wrappedMiddleNode = new WrappedMiddleNode(intake);
+        wrappedMiddleNode = new WrappedMiddleNode(arm);
         wrappedMiddleNode.schedule();
     }
 
@@ -37,9 +37,9 @@ public class MiddleNode extends CommandBase {
             }
 
             addCommands(
-                new IntakeExtend(intake, 0),
-                new IntakeTurn(intake, angle),
-                new IntakeExtend(intake, length)
+                new IntakeExtend(arm, 0),
+                new IntakeTurn(arm, angle),
+                new IntakeExtend(arm, length)
             );
         }
     }

--- a/src/main/java/frc/team5115/Commands/Intake/CombinedIntakeCommands/ShelfSubstation.java
+++ b/src/main/java/frc/team5115/Commands/Intake/CombinedIntakeCommands/ShelfSubstation.java
@@ -6,10 +6,7 @@ import frc.team5115.Commands.Intake.RawIntakeCommands.IntakeExtend;
 import frc.team5115.Commands.Intake.RawIntakeCommands.IntakeTurn;
 
 public class ShelfSubstation extends SequentialCommandGroup {
-    Arm intake;
-
     public ShelfSubstation(Arm arm){
-        this.intake = arm;
         addCommands(
             new IntakeExtend(arm, 0),
             new IntakeTurn(arm, 8),

--- a/src/main/java/frc/team5115/Commands/Intake/CombinedIntakeCommands/Stow.java
+++ b/src/main/java/frc/team5115/Commands/Intake/CombinedIntakeCommands/Stow.java
@@ -1,7 +1,6 @@
 package frc.team5115.Commands.Intake.CombinedIntakeCommands;
 
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
-import frc.team5115.Classes.Hardware.HardwareArm;
 import frc.team5115.Classes.Hardware.HardwareIntake;
 import frc.team5115.Classes.Software.Arm;
 import frc.team5115.Commands.Intake.StartupWinch;
@@ -9,11 +8,11 @@ import frc.team5115.Commands.Intake.RawIntakeCommands.IntakeExtend;
 import frc.team5115.Commands.Intake.RawIntakeCommands.IntakeTurn;
 
 public class Stow extends SequentialCommandGroup {
-    public Stow(Arm intake, HardwareArm h, HardwareIntake I){
+    public Stow(Arm arm, HardwareIntake intake){
         addCommands(
-            new IntakeExtend(intake, 0),
-            new IntakeTurn(intake, -90),
-            new StartupWinch(intake, h, I)
+            new IntakeExtend(arm, 0),
+            new IntakeTurn(arm, -90),
+            new StartupWinch(arm, intake)
         );
     }
 }

--- a/src/main/java/frc/team5115/Commands/Intake/StartupWinch.java
+++ b/src/main/java/frc/team5115/Commands/Intake/StartupWinch.java
@@ -6,14 +6,12 @@ import frc.team5115.Classes.Hardware.*;
 
 public class StartupWinch extends CommandBase{
     private Arm arm;
-    private HardwareArm hardwareArm;
     private HardwareIntake claw;
     private Timer timer;
     private Timer innerTimer;
 
-    public StartupWinch(Arm arm, HardwareArm hardwareArm, HardwareIntake claw){
+    public StartupWinch(Arm arm, HardwareIntake claw){
         this.arm = arm;
-        this.hardwareArm = hardwareArm;
         this.claw = claw;
         timer = new Timer();
         timer.start();
@@ -24,8 +22,8 @@ public class StartupWinch extends CommandBase{
         timer.reset();
         arm.armcontrol = false;
         claw.open();
-        hardwareArm.setBottomWinch(-0.1);
-        hardwareArm.setTopWinch(-0.37);
+        arm.setBottomWinchSpeed(-0.1);
+        arm.setTopWinchSpeed(-0.37);
         claw.TurnIn();
     }
 
@@ -43,7 +41,7 @@ public class StartupWinch extends CommandBase{
 
     public boolean isFinished() {
         if(timer.get() > 0.5){
-            if (Math.abs(hardwareArm.getBottomVelocity())<1 && Math.abs(hardwareArm.getTopVelocity())<1){
+            if (Math.abs(arm.getBottomWinchVelocity())<1 && Math.abs(arm.getTopWinchVelocity())<1){
                 return true;
             }
         }

--- a/src/main/java/frc/team5115/Constants.java
+++ b/src/main/java/frc/team5115/Constants.java
@@ -35,6 +35,9 @@ public class Constants{
     // distance between the left wheels and the right wheels in meters
     // 0.70 for wide, 0.57 for long
     public static final double TRACKING_WIDTH_METERS = 0.70;
+    // distance between the front and back axles in meters
+    // UNKOWN!!!!! somebody needs to measure this. 0.58 is ARBITRARY
+    public static final double TRACKING_LENGTH_METERS = 0.58;
 
     public static final double TARGET_ANGLE = 1;
 

--- a/src/main/java/frc/team5115/Robot/RobotContainer.java
+++ b/src/main/java/frc/team5115/Robot/RobotContainer.java
@@ -24,7 +24,6 @@ public class RobotContainer {
     private final Drivetrain drivetrain;
     private final HardwareIntake intake;
     private final Arm arm;
-    private final HardwareArm hardwareArm;
     private final StartupWinch startupWinch;
     private final ShuffleboardTab tab;
     private final GenericEntry center;
@@ -42,10 +41,14 @@ public class RobotContainer {
 
         photonVision = new PhotonVision();
         intake = new HardwareIntake();
-        hardwareArm = new HardwareArm(navx, i2cHandler);
-        arm = new Arm(hardwareArm, intake);
-        drivetrain = new Drivetrain(photonVision, arm, navx);
-        startupWinch = new StartupWinch(arm, hardwareArm, intake);
+
+        HardwareArm hardwareArm = new HardwareArm(navx, i2cHandler);
+        arm = new Arm(intake, hardwareArm);
+
+        HardwareDrivetrain hardwareDrivetrain = new HardwareDrivetrain(arm);
+        drivetrain = new Drivetrain(photonVision, hardwareDrivetrain, navx);
+        
+        startupWinch = new StartupWinch(arm, intake);
         
         tab = Shuffleboard.getTab("SmartDashboard");
         center = tab.add("Are we doing center balacing auto?", false).getEntry();
@@ -62,7 +65,7 @@ public class RobotContainer {
         new JoystickButton(joy1, XboxController.Button.kY.value).onTrue(new HighNode(arm)); // high node
         new JoystickButton(joy1, XboxController.Button.kB.value).onTrue(new MiddleNode(arm)); // middle node
         new JoystickButton(joy1, XboxController.Button.kA.value).onTrue(new GroundPickup(arm)); // low node/ground pickup
-        new JoystickButton(joy1, XboxController.Button.kStart.value).onTrue(new Stow(arm, hardwareArm, intake)); // stow fully
+        new JoystickButton(joy1, XboxController.Button.kStart.value).onTrue(new Stow(arm, intake)); // stow fully
         new JoystickButton(joy1, XboxController.Button.kBack.value).onTrue(new StowCone(arm)); // stow with cone
     }
 
@@ -101,7 +104,7 @@ public class RobotContainer {
         arm.armcontrolangle = true;
         centerAuto = center.getBoolean(false);
         System.out.println("Good auto? " + centerAuto + "!!!!!!!");
-        autoCommandGroup = new AutoCommandGroup(drivetrain, arm, hardwareArm, intake, centerAuto);
+        autoCommandGroup = new AutoCommandGroup(drivetrain, arm, intake, centerAuto);
         autoCommandGroup.schedule();
     }
 


### PR DESCRIPTION
I renamed a bunch of variables to better names: sometimes instances of hardwareArm were called intake.
I also changed it so that nothing needs to call hardwareArm except arm because that is better and matches how it works for drivetrain. 
hardwareDrivetrain and hardwareArm were moved into RobotContainer but only get passed into Drivetrain and Arm, respectively. This allows for easier mocking in the future.
All commands were updated to reflect these changes and all arm functions were checked on the robot.